### PR TITLE
My change for grabbing any section

### DIFF
--- a/grab_quiz.py
+++ b/grab_quiz.py
@@ -95,7 +95,7 @@ def main():
 
     to_file(assignment, submissions, section)
 
-    print('Submissions are in file {0}.txt'.format(assignment))
+    print('Submissions are in file {0}-{1}.txt'.format(assignment,section))
     exit()
 
 

--- a/grab_quiz.py
+++ b/grab_quiz.py
@@ -60,9 +60,9 @@ def extract_submissions(driver, links):
     driver.close()
     return submissions
 
-def to_file(assignment, submissions):
+def to_file(assignment, submissions, section):
 
-    fout = open(assignment + '.txt', 'w')
+    fout = open(assignment + '-' + section + '.txt', 'w')
 
     for sub in submissions:
         fout.write(sub[0] + '\n')
@@ -93,7 +93,7 @@ def main():
 
     submissions = extract_submissions(res_tup[0], res_tup[1])
 
-    to_file(assignment, submissions)
+    to_file(assignment, submissions, section)
 
     print('Submissions are in file {0}.txt'.format(assignment))
     exit()

--- a/grab_quiz.py
+++ b/grab_quiz.py
@@ -24,7 +24,8 @@ def to_assignment(driver, assignment, section):
     for ele in driver.find_elements_by_class_name('collapsible-header'):
         ele.click()
 
-    driver.find_element_by_partial_link_text('Grade section ' + section).click()
+    driver.find_element_by_partial_link_text('Grade all').click()
+    driver.find_element_by_xpath('//label[input]').send_keys(section)
 
     return driver
 
@@ -51,11 +52,11 @@ def extract_submissions(driver, links):
         driver.get(base + link)
         soup = BeautifulSoup(driver.page_source, 'html.parser')
         name = soup.find('h2').contents[-1].strip().strip('(').strip(')')
-        
+
         for ele in soup.find_all('code'):
             submissions.append((name, ele.text))
             break
-    
+
     driver.close()
     return submissions
 
@@ -100,4 +101,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
Instead of scrolling through, I took advantage of the fact that when searching for a section, autolab automatically omits all other sections quizzes, so it finds the search input on the page and then sends the section keys to it and downloads the files as you were doing normally